### PR TITLE
Added prepare build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
+    "prepare": "npm run build",
     "preview": "vite preview",
     "lint": "eslint src --fix",
     "docs:dev": "vitepress dev docs",


### PR DESCRIPTION
I've noticed that when pulling this library into a project, it's never built for use. This requires the developer to go into the _node_modules_ folder and manually run the build process. Not the end of the world, but not as straightforward as it could be.

This PR simply adds a `prepare` build script to call `npm run build` so anyone using it doesn't have to do so manually.