### PR TITLE
fix(flash-card): correct processing of the maxRotation prop

### DIFF
--- a/src/FlashCard.vue
+++ b/src/FlashCard.vue
@@ -38,10 +38,9 @@ const {
   ...params
 } = defineProps<FlashCardProps>()
 
-const transformStyle = customTransformStyle ?? ((position: DragPosition) =>
-  `transform: rotate(${position.delta * maxRotation}deg)`
-)
-
+const transformStyle = (position: DragPosition) =>
+  (customTransformStyle ?? ((pos: DragPosition) =>
+    `transform: rotate(${pos.delta * maxRotation}deg)`))(position)
 
 const emit = defineEmits<{
   /**


### PR DESCRIPTION
Fixed the logic of using the `maxRotation` prop in the FlashCard component.  
Previously, the default function `transformStyle` rigidly used config.defaultMaxRotation, which is why the passed prop was ignored.  

What has been changed:  
- The destructuring of the props is left unchanged for readability.  
- `transformStyle` now correctly uses `_maxRotation' if the prop is passed from the outside.  

Now the external `maxRotation` correctly affects the card rotation when dragging. :)