### PR TITLE
feat: expose activeItemKey in default slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ function blurTransform(position) {
 
 | Slot Name | Props | Description |
 |-----------|-------|-------------|
-| default | `{ item: T }` | Main content of the card (front side) |
+| default | `{ item: T, activeItemKey: number `|` string }` | Main content of the card (front side) |
 | actions | `{ restore: () => void, reject: () => void, approve: () => void, isEnd: boolean, canRestore: boolean }` | Custom actions UI. `restore` returns to previous card, `reject`/`approve` trigger swipe animations, `isEnd` whether all cards have been swiped, `canRestore` whether there is a previous card to restore to |
 | approve | `{ item: T }` | Content shown when swiping right (approval indicator) |
 | reject | `{ item: T }` | Content shown when swiping left (rejection indicator) |

--- a/docs/api/flashcards.md
+++ b/docs/api/flashcards.md
@@ -240,16 +240,19 @@ function blurTransform(position) {
 
 ### `default`
 
-- **Props:** `{ item: T }`
+- **Props:** `{ item: T, activeItemKey: number | string }`
 - **Description:** Main content of the card (front side).
 
 ```vue
 <template>
   <FlashCards :items="cards">
-    <template #default="{ item }">
+    <template #default="{ item, activeItemKey }">
       <div class="card-content">
         {{ item.title }}
       </div>
+       <p>
+        Active card = {{ activeItemKey }}
+      </p>
     </template>
   </FlashCards>
 </template>

--- a/src/FlashCards.vue
+++ b/src/FlashCards.vue
@@ -67,7 +67,7 @@ const emit = defineEmits<{
 }>()
 
 defineSlots<{
-  default: (props: { item: T }) => any
+  default: (props: { item: T, activeItemKey: string | number }) => any
   reject?: (props: { item: T, delta: number }) => any
   approve?: (props: { item: T, delta: number }) => any
   actions?: (props: {
@@ -234,7 +234,7 @@ defineExpose({
           @dragend="emit('dragend', item)"
         >
           <template #default>
-            <slot :item="item" />
+            <slot :item="item" :active-item-key="currentItemId" />
           </template>
           <template #reject="{ delta }">
             <slot name="reject" :item="item" :delta="delta" />
@@ -263,7 +263,7 @@ defineExpose({
           @dragend="emit('dragend', item)"
         >
           <template #default>
-            <slot :item="item" />
+              <slot :item="item" :active-item-key="currentItemId" />
           </template>
           <template #reject="{ delta }">
             <slot name="reject" :item="item" :delta="delta" />


### PR DESCRIPTION
## Description

This pull request updates the FlashCards component to provide additional context to slot consumers by exposing the active card's key. The main change is the addition of the activeItemKey prop to the default slot, allowing users to easily identify which card is currently active. This improvement is reflected in the component implementation, type definitions, documentation, and usage examples.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 🔧 Maintenance (dependency updates, config changes, etc.)


### Slot API and Type Updates

* The default slot now receives `{ item: T, activeItemKey: string | number }` instead of just `{ item: T }`.
* The slot invocation in the template passes both `item` and `active-item-key` (`currentItemId`) to the default slot, ensuring the new prop is available at runtime.

### Documentation and Example Updates

* The slot API documentation in `README.md` and `docs/api/flashcards.md` has been updated to describe the new `activeItemKey` prop for the default slot. 

## Testing

- [x] Tests pass locally
- [ ] Added tests for new functionality (if applicable)
- [ ] Manual testing completed

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

## Note
I couldn't run all the tests because this error occurred:
`This error originated in "tests/FlashCards/exposed-reset.test.ts" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.`
